### PR TITLE
Add robust logging and global error handling

### DIFF
--- a/src/vsm_gui/app.py
+++ b/src/vsm_gui/app.py
@@ -1,13 +1,38 @@
 from __future__ import annotations
 
 import sys
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import QtMsgType, qInstallMessageHandler
+from PyQt6.QtWidgets import QApplication, QMessageBox
 
 from .main_window import MainWindow
+from .utils.logging import LOG_FILE, logger
 
 
 def main() -> None:
     """Entry point for the VSM GUI application."""
+    def handle_exception(exc_type, exc, tb) -> None:  # noqa: ANN001
+        logger.error("Uncaught exception", exc_info=(exc_type, exc, tb))
+        msg = QMessageBox()
+        msg.setIcon(QMessageBox.Icon.Critical)
+        msg.setWindowTitle("Error")
+        msg.setText(
+            f"{exc_type.__name__}: {exc}\n\nSee log for details:\n{LOG_FILE}"
+        )
+        msg.exec()
+
+    def qt_message_handler(msg_type: QtMsgType, context, message: str) -> None:  # noqa: ANN001
+        mapping = {
+            QtMsgType.QtDebugMsg: logger.debug,
+            QtMsgType.QtInfoMsg: logger.info,
+            QtMsgType.QtWarningMsg: logger.warning,
+            QtMsgType.QtCriticalMsg: logger.error,
+            QtMsgType.QtFatalMsg: logger.critical,
+        }
+        mapping.get(msg_type, logger.info)(message)
+
+    sys.excepthook = handle_exception
+    qInstallMessageHandler(qt_message_handler)
+
     app = QApplication(sys.argv)
     window = MainWindow()
     window.show()

--- a/src/vsm_gui/main_window.py
+++ b/src/vsm_gui/main_window.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pandas as pd
-from PyQt6.QtGui import QAction
+from PyQt6.QtCore import QUrl
+from PyQt6.QtGui import QAction, QDesktopServices
 from PyQt6.QtWidgets import (
     QDialog,
     QFileDialog,
@@ -16,6 +17,7 @@ from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as Navigation
 from .file_io.loader import read_csv
 from .plotting.manager import PlotManager
 from .utils import errors
+from .utils.logging import LOG_FILE
 from .widgets.axis_mapping import AxisMappingDialog
 from .widgets.file_picker import pick_csv_files
 from .widgets.plot_pane import PlotPane
@@ -87,6 +89,9 @@ class MainWindow(QMainWindow):
         about_act = QAction(ABOUT_TEXT, self)
         about_act.triggered.connect(self.show_about)
         help_menu.addAction(about_act)
+        show_log_act = QAction("Show Log File", self)
+        show_log_act.triggered.connect(self.show_log_file)
+        help_menu.addAction(show_log_act)
 
     def open_files(self) -> None:
         paths = [Path(p) for p in pick_csv_files(self)]
@@ -136,3 +141,6 @@ class MainWindow(QMainWindow):
 
     def show_about(self) -> None:
         errors.show_info(self, ABOUT_MESSAGE, ABOUT_TEXT)
+
+    def show_log_file(self) -> None:
+        QDesktopServices.openUrl(QUrl.fromLocalFile(str(LOG_FILE)))

--- a/src/vsm_gui/utils/logging.py
+++ b/src/vsm_gui/utils/logging.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+LOG_DIR = Path.home() / ".vsm-gui"
+LOG_FILE = LOG_DIR / "vsm.log"
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger("vsm_gui")
+logger.setLevel(logging.INFO)
+
+if not logger.handlers:
+    handler = RotatingFileHandler(LOG_FILE, maxBytes=1_000_000, backupCount=3)
+    formatter = logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+__all__ = ["logger", "LOG_FILE"]


### PR DESCRIPTION
## Summary
- Add rotating file logger at `~/.vsm-gui/vsm.log`
- Hook `sys.excepthook` and Qt's message handler to log uncaught errors and Qt messages
- Provide menu action to open the log file from the Help menu

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a4f9ff0648324b45ccf67ff465078