### PR TITLE
feat: allow changing axes after import

### DIFF
--- a/src/vsm_gui/plotting/manager.py
+++ b/src/vsm_gui/plotting/manager.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, List
 
 import matplotlib
+import numpy as np
 import pandas as pd
 
 from ..widgets.plot_pane import PlotPane
@@ -14,10 +15,12 @@ class PlotManager:
 
     def __init__(self, pane: PlotPane) -> None:
         self.pane = pane
-        self.datasets: Dict[str, Tuple[pd.DataFrame, str, str]] = {}
+        self.datasets: Dict[str, pd.DataFrame] = {}
         cycle = matplotlib.rcParams["axes.prop_cycle"].by_key()
         self._colors = cycle.get("color", [])
         self._index = 0
+        self._x_name: str | None = None
+        self._y_name: str | None = None
 
     def _next_color(self) -> str | None:
         if not self._colors:
@@ -32,15 +35,56 @@ class PlotManager:
         self._index = 0
         self.pane.clear()
 
-    def add(self, label: str, df: pd.DataFrame, x: str, y: str) -> None:
-        """Add a dataframe to the plot."""
-        color = self._next_color()
-        self.datasets[label] = (df, x, y)
-        self.pane.plot_dataframe(df, x, y, label, color=color)
+    def add(self, label: str, df: pd.DataFrame) -> None:
+        """Store a dataframe for plotting."""
+        self.datasets[label] = df
 
-    def set_labels(self, xlabel: str, ylabel: str) -> None:
-        """Set axes labels."""
-        self.pane.set_labels(xlabel, ylabel)
+    def set_axis_names(self, x_name: str, y_name: str) -> None:
+        """Record the axis column names to use for plotting."""
+        self._x_name = x_name
+        self._y_name = y_name
+        self.pane.set_labels(x_name, y_name)
+
+    def replot_all(self) -> List[str]:
+        """Rebuild the figure using stored datasets and axis names.
+
+        Returns a list of warning messages for datasets that could not be
+        plotted.
+        """
+        self.pane.clear()
+        skipped: List[str] = []
+
+        if self._x_name is None or self._y_name is None:
+            return skipped
+
+        for label, df in self.datasets.items():
+            if (
+                self._x_name not in df.columns
+                or self._y_name not in df.columns
+            ):
+                skipped.append(
+                    f"{label}: missing column '{self._x_name}' or '{self._y_name}'"
+                )
+                continue
+
+            x = pd.to_numeric(df[self._x_name], errors="coerce")
+            y = pd.to_numeric(df[self._y_name], errors="coerce")
+            clean = (
+                pd.DataFrame({self._x_name: x, self._y_name: y})
+                .replace([np.inf, -np.inf], pd.NA)
+                .dropna()
+            )
+            if len(clean) < 2:
+                skipped.append(f"{label}: not enough valid data")
+                continue
+
+            color = self._next_color()
+            self.pane.plot_dataframe(
+                clean, self._x_name, self._y_name, label, color=color
+            )
+
+        self.reset_view()
+        return skipped
 
     def export_png(self, path: Path) -> None:
         """Export the current figure as a PNG file."""

--- a/src/vsm_gui/widgets/axis_mapping.py
+++ b/src/vsm_gui/widgets/axis_mapping.py
@@ -6,6 +6,7 @@ from PyQt6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QFormLayout,
+    QLabel,
     QWidget,
 )
 
@@ -43,9 +44,13 @@ class AxisMappingDialog(QDialog):
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
 
+        note = QLabel("Files missing the selected columns will be skipped.")
+        note.setWordWrap(True)
+
         layout = QFormLayout(self)
         layout.addRow(LABEL_X, self._x_combo)
         layout.addRow(LABEL_Y, self._y_combo)
+        layout.addRow(note)
         layout.addWidget(buttons)
 
     def get_mapping(self) -> tuple[str, str]:

--- a/src/vsm_gui/widgets/plot_pane.py
+++ b/src/vsm_gui/widgets/plot_pane.py
@@ -41,11 +41,15 @@ class PlotPane(FigureCanvasQTAgg):
         """Export the current figure to a PNG file."""
         self.figure.savefig(path, format="png", dpi=150)
 
-    def reset_view(self) -> None:
+    def autoscale(self) -> None:
         """Autoscale the axes and redraw."""
         self.axes.relim()
         self.axes.autoscale()
         self.draw_idle()
+
+    def reset_view(self) -> None:
+        """Reset the view to show all data."""
+        self.autoscale()
 
     def toggle_grid(self, enabled: bool) -> None:
         """Toggle the grid visibility."""


### PR DESCRIPTION
## Summary
- add View > Change Axes… action
- allow plotting manager to remember axis names and replot datasets
- expand axis selection dialog and document skipped files
- autoscale plot pane after replots

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9f11b3a08324b1859536fa430597