### PR TITLE
Add plot interaction toggles and data cursor

### DIFF
--- a/src/vsm_gui/main_window.py
+++ b/src/vsm_gui/main_window.py
@@ -59,14 +59,24 @@ class MainWindow(QMainWindow):
     def _init_toolbar(self) -> None:
         grid = QAction("Grid", self)
         grid.setCheckable(True)
+        grid.setChecked(True)
         grid.triggered.connect(self.pane.toggle_grid)
         self.navbar.addAction(grid)
+
+        minor = QAction("Minor Ticks", self)
+        minor.setCheckable(True)
+        minor.setChecked(True)
+        minor.triggered.connect(self.pane.toggle_minor_ticks)
+        self.navbar.addAction(minor)
 
         legend = QAction("Legend", self)
         legend.setCheckable(True)
         legend.setChecked(True)
-        legend.triggered.connect(self.pane.show_legend)
+        legend.triggered.connect(self.pane.toggle_legend)
         self.navbar.addAction(legend)
+
+        self._grid_action = grid
+        self._minor_action = minor
         self._legend_action = legend
 
     def _init_menu(self) -> None:
@@ -85,6 +95,10 @@ class MainWindow(QMainWindow):
         reset_act = QAction(RESET_TEXT, self)
         reset_act.triggered.connect(self.manager.reset_view)
         view_menu.addAction(reset_act)
+        view_menu.addSeparator()
+        view_menu.addAction(self._grid_action)
+        view_menu.addAction(self._minor_action)
+        view_menu.addAction(self._legend_action)
 
         help_menu = menu.addMenu("Help")
         about_act = QAction(ABOUT_TEXT, self)
@@ -133,8 +147,7 @@ class MainWindow(QMainWindow):
                 self.manager.add(path.stem, df, x_col, y_col)
 
             self.manager.set_labels(x_col, y_col)
-            self.pane.show_legend(True)
-            self._legend_action.setChecked(True)
+            self.pane.toggle_legend(self._legend_action.isChecked())
         except Exception as exc:  # noqa: BLE001
             logger.exception("Failed to open files")
             QMessageBox.critical(self, "Error", str(exc))

--- a/src/vsm_gui/widgets/plot_pane.py
+++ b/src/vsm_gui/widgets/plot_pane.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
+import numpy as np
 import pandas as pd
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
+from matplotlib.lines import Line2D
 
 plt.style.use("dark_background")
+plt.rcParams.update({"font.size": 10, "grid.alpha": 0.3})
 
 
 class PlotPane(FigureCanvasQTAgg):
@@ -19,16 +22,34 @@ class PlotPane(FigureCanvasQTAgg):
         super().__init__(self.figure)
         self.axes = self.figure.add_subplot(111)
 
+        self._grid_on = True
+        self._minor_on = True
+        self._legend_on = True
+
+        self._annotation = None
+        self._cursor_line: Line2D | None = None
+
+        self.toggle_grid(True)
+        self.toggle_minor_ticks(True)
+        self.enable_data_cursor()
+
     def clear(self) -> None:
         """Remove all plots from the canvas."""
         self.axes.cla()
+        self.toggle_grid(self._grid_on)
+        self.toggle_minor_ticks(self._minor_on)
+        self._annotation = None
+        self._cursor_line = None
         self.draw_idle()
 
     def plot_dataframe(
         self, df: pd.DataFrame, x: str, y: str, label: str, color: str | None = None
     ) -> None:
         """Plot a dataframe on the canvas."""
-        self.axes.plot(df[x], df[y], label=label, color=color)
+        (line,) = self.axes.plot(df[x], df[y], label=label, color=color)
+        line.set_picker(True)
+        if self._legend_on:
+            self.axes.legend(loc="best")
         self.draw_idle()
 
     def set_labels(self, xlabel: str, ylabel: str) -> None:
@@ -49,14 +70,71 @@ class PlotPane(FigureCanvasQTAgg):
 
     def toggle_grid(self, enabled: bool) -> None:
         """Toggle the grid visibility."""
-        self.axes.grid(enabled)
+        self._grid_on = enabled
+        self.axes.grid(enabled, which="both")
         self.draw_idle()
 
-    def show_legend(self, visible: bool) -> None:
+    def toggle_minor_ticks(self, enabled: bool) -> None:
+        """Toggle minor ticks on both axes."""
+        self._minor_on = enabled
+        if enabled:
+            self.axes.minorticks_on()
+        else:
+            self.axes.minorticks_off()
+        if self._grid_on:
+            self.axes.grid(self._grid_on, which="both")
+        self.draw_idle()
+
+    def toggle_legend(self, visible: bool) -> None:
         """Toggle legend visibility."""
+        self._legend_on = visible
         legend = self.axes.get_legend()
-        if visible:
-            self.axes.legend()
+        handles, labels = self.axes.get_legend_handles_labels()
+        if visible and handles:
+            self.axes.legend(loc="best")
         elif legend:
             legend.remove()
+        self.draw_idle()
+
+    def enable_data_cursor(self) -> None:
+        """Enable a simple data cursor."""
+        self.mpl_connect("pick_event", self._on_pick)
+        self.mpl_connect("motion_notify_event", self._on_motion)
+
+    def _on_pick(self, event) -> None:
+        if event.mouseevent.button != 1 or not isinstance(event.artist, Line2D):
+            return
+        line: Line2D = event.artist
+        if self._annotation and line is self._cursor_line:
+            self._annotation.remove()
+            self._annotation = None
+            self._cursor_line = None
+            self.draw_idle()
+            return
+        xdata, ydata = line.get_data()
+        ind = event.ind[0]
+        x, y = xdata[ind], ydata[ind]
+        if self._annotation:
+            self._annotation.remove()
+        self._cursor_line = line
+        self._annotation = self.axes.annotate(
+            f"({x:.2f}, {y:.2f})",
+            xy=(x, y),
+            xytext=(10, 10),
+            textcoords="offset points",
+            bbox=dict(boxstyle="round,pad=0.3", fc=plt.rcParams["axes.facecolor"], alpha=0.8),
+        )
+        self.draw_idle()
+
+    def _on_motion(self, event) -> None:
+        if not self._annotation or not self._cursor_line or event.inaxes != self.axes:
+            return
+        x = event.xdata
+        if x is None:
+            return
+        xdata, ydata = self._cursor_line.get_data()
+        idx = int(np.argmin(np.abs(xdata - x)))
+        x0, y0 = xdata[idx], ydata[idx]
+        self._annotation.xy = (x0, y0)
+        self._annotation.set_text(f"({x0:.2f}, {y0:.2f})")
         self.draw_idle()


### PR DESCRIPTION
## Summary
- Default plots now show grid, minor ticks, and a legend with a dark-friendly style.
- Added toolbar and menu toggles for grid, minor ticks, and legend visibility.
- Introduced a simple data cursor that displays (x, y) values when clicking on plotted lines.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b9f22aa1c832480488c7788bff62a