### PR TITLE
feat: add dataset model and parser plugin system

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,29 @@
+# Architecture Overview
+
+This project provides a light‑weight framework for viewing and analysing VSM
+(data).  The refactor introduces three key extension points:
+
+## Dataset model
+
+`vsm_gui.model.Dataset` wraps a pandas `DataFrame` together with metadata such
+as column names and units.  It offers helpers like `select_xy()` which validates
+and cleans numeric columns and `clone()` for copying datasets.  Plotting code
+and analyses use this typed object instead of raw frames.
+
+## Parser plugins
+
+File readers implement the `ParserPlugin` protocol
+(`vsm_gui.file_io.parsers`).  Plugins register themselves via
+`register()` and are discovered by `load_any()`.  The built‑in CSV parser is an
+example; new formats can be supported by providing a module that implements the
+protocol and calls `register` when imported.
+
+## Services
+
+Utility services under `vsm_gui.services` centralise domain logic.  The initial
+`units` service performs numeric coercion and acts as a placeholder for future
+unit conversion features.
+
+These components decouple data loading, analysis and rendering, making it easy
+to add new file types, analyses or plotting modes without touching existing
+code.

--- a/src/vsm_gui/__init__.py
+++ b/src/vsm_gui/__init__.py
@@ -1,6 +1,11 @@
 """VSM GUI package."""
 
-from .app import main
-
 __all__ = ["main"]
 __version__ = "0.1.0"
+
+
+def main() -> None:  # pragma: no cover - thin wrapper
+    """Entry point wrapper for ``python -m vsm_gui``."""
+    from .app import main as _main
+
+    _main()

--- a/src/vsm_gui/file_io/parsers/__init__.py
+++ b/src/vsm_gui/file_io/parsers/__init__.py
@@ -1,0 +1,6 @@
+from .base import PARSERS, ParserPlugin, load_any, register
+
+# Register built-in parsers
+from . import csv  # noqa: F401
+
+__all__ = ["PARSERS", "ParserPlugin", "load_any", "register"]

--- a/src/vsm_gui/file_io/parsers/base.py
+++ b/src/vsm_gui/file_io/parsers/base.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Protocol
+
+import pandas as pd
+
+
+class ParserPlugin(Protocol):
+    name: str
+    extensions: tuple[str, ...]
+
+    def sniff(self, path: Path, head: str) -> bool:
+        ...
+
+    def load(self, path: Path) -> pd.DataFrame:
+        ...
+
+
+PARSERS: list[ParserPlugin] = []
+
+
+def register(parser: ParserPlugin) -> None:
+    PARSERS.append(parser)
+
+
+def load_any(path: Path) -> pd.DataFrame:
+    text = Path(path).read_text(errors="ignore")[:4096]
+    for parser in PARSERS:
+        if any(path.suffix.lower() == ext for ext in parser.extensions) or parser.sniff(path, text):
+            return parser.load(path)
+    for sep in [",", "\t", ";"]:
+        try:
+            return pd.read_csv(path, sep=sep)
+        except Exception:
+            pass
+    raise ValueError(f"No parser could read {path}")

--- a/src/vsm_gui/file_io/parsers/csv.py
+++ b/src/vsm_gui/file_io/parsers/csv.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from .base import ParserPlugin, register
+
+
+class CSVParser:
+    name = "csv"
+    extensions = (".csv", ".tsv", ".txt")
+
+    def sniff(self, path: Path, head: str) -> bool:
+        return "," in head or "\t" in head
+
+    def load(self, path: Path) -> pd.DataFrame:
+        return pd.read_csv(path, sep=None, engine="python", encoding="utf-8-sig")
+
+
+register(CSVParser())

--- a/src/vsm_gui/main_window.py
+++ b/src/vsm_gui/main_window.py
@@ -14,7 +14,7 @@ from PyQt6.QtWidgets import (
 from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
 import pandas as pd
 
-from .file_io.loader import read_csv
+from .file_io.parsers import load_any
 from .plotting.manager import PlotManager
 from .utils import errors
 from .utils.logging import LOG_FILE, logger
@@ -128,7 +128,7 @@ class MainWindow(QMainWindow):
             valid_paths: list[Path] = []
             for path in paths:
                 try:
-                    df = read_csv(path)
+                    df = load_any(path)
                 except Exception as exc:  # noqa: BLE001
                     errors.show_error(self, f"Failed to read {path.name}: {exc}")
                     continue
@@ -178,8 +178,8 @@ class MainWindow(QMainWindow):
         if not self.manager.datasets:
             return
         headers: set[str] = set()
-        for df in self.manager.datasets.values():
-            headers.update(df.columns)
+        for ds in self.manager.datasets.values():
+            headers.update(ds.df.columns)
         dialog = AxisMappingDialog(sorted(headers), self._last_x, self._last_y, self)
         if dialog.exec() != QDialog.DialogCode.Accepted:
             return

--- a/src/vsm_gui/model/__init__.py
+++ b/src/vsm_gui/model/__init__.py
@@ -1,0 +1,3 @@
+from .dataset import Dataset
+
+__all__ = ["Dataset"]

--- a/src/vsm_gui/model/dataset.py
+++ b/src/vsm_gui/model/dataset.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+import numpy as np
+import pandas as pd
+
+from ..services import units
+
+
+@dataclass
+class Dataset:
+    """Container for a loaded dataset."""
+
+    label: str
+    df: pd.DataFrame
+    x_name: str | None = None
+    y_name: str | None = None
+    units: Dict[str, str] = field(default_factory=dict)
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+    def select_xy(self, x: str, y: str) -> pd.DataFrame:
+        """Return a cleaned numeric frame with the requested columns."""
+        if x not in self.df.columns or y not in self.df.columns:
+            raise KeyError(f"Missing column '{x}' or '{y}'")
+        data = self.df[[x, y]].copy()
+        data = units.to_numeric(data, [x, y])
+        return data.replace([np.inf, -np.inf], pd.NA).dropna()
+
+    def clone(self, label: Optional[str] = None) -> Dataset:
+        """Return a shallow copy optionally with a new label."""
+        return Dataset(
+            label=label or self.label,
+            df=self.df.copy(),
+            x_name=self.x_name,
+            y_name=self.y_name,
+            units=self.units.copy(),
+            meta=self.meta.copy(),
+        )

--- a/src/vsm_gui/services/__init__.py
+++ b/src/vsm_gui/services/__init__.py
@@ -1,0 +1,3 @@
+from . import units
+
+__all__ = ["units"]

--- a/src/vsm_gui/services/units.py
+++ b/src/vsm_gui/services/units.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+import pandas as pd
+
+# Basic unit labels -- extend as needed
+MOMENT_UNITS = {
+    "emu": "electromagnetic unit",
+    "A/m": "ampere per meter",
+}
+
+
+def to_numeric(df: pd.DataFrame, cols: Iterable[str]) -> pd.DataFrame:
+    """Coerce selected columns to numeric values."""
+    result = df.copy()
+    for col in cols:
+        result[col] = pd.to_numeric(result[col], errors="coerce")
+    return result
+
+
+def convert_moment(
+    df: pd.DataFrame,
+    from_unit: str,
+    to_unit: str,
+    params: Mapping[str, float] | None = None,
+) -> pd.DataFrame:
+    """Convert magnetic moment units.
+
+    Currently only supports a pass-through when units match.
+    """
+    if from_unit == to_unit:
+        return df
+    raise NotImplementedError(
+        f"Conversion from {from_unit!r} to {to_unit!r} is not implemented"
+    )

--- a/tests/test_extension_points.py
+++ b/tests/test_extension_points.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from vsm_gui.file_io.parsers import load_any, register, ParserPlugin
+from vsm_gui.model import Dataset
+
+
+class DummyParser:
+    name = "dummy"
+    extensions = (".dum",)
+
+    def sniff(self, path: Path, head: str) -> bool:  # noqa: D401
+        return head.startswith("dummy")
+
+    def load(self, path: Path) -> pd.DataFrame:
+        return pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+
+
+def test_parser_registration(tmp_path: Path) -> None:
+    parser: ParserPlugin = DummyParser()
+    register(parser)
+    path = tmp_path / "file.dum"
+    path.write_text("dummy")
+    df = load_any(path)
+    assert list(df.columns) == ["x", "y"]
+
+
+def test_dataset_model() -> None:
+    df = pd.DataFrame({"a": [1, 2, "bad"], "b": [4.0, float("inf"), 6.0]})
+    ds = Dataset("test", df)
+    clean = ds.select_xy("a", "b")
+    assert list(clean.columns) == ["a", "b"]
+    assert len(clean) == 1
+    clone = ds.clone(label="copy")
+    assert clone.label == "copy" and clone.df.equals(df)


### PR DESCRIPTION
## Summary
- introduce `Dataset` model and units service to centralize validation
- add plugin-based file parser registry with default CSV parser
- refactor `PlotManager` and analysis tools to use datasets
- document architecture and add tests for extension points

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c9d436f088324bb3014f5793b2bcd