### PR TITLE
Add optional markers for analysis results

### DIFF
--- a/src/vsm_gui/plotting/manager.py
+++ b/src/vsm_gui/plotting/manager.py
@@ -206,3 +206,7 @@ class PlotManager:
         """Reset the axes limits."""
         self.pane.reset_view()
 
+    def clear_markers(self) -> None:
+        """Remove any marker annotations from the plot."""
+        self.pane.clear_markers()
+


### PR DESCRIPTION
## Summary
- add PlotPane helpers for markers and reference lines
- allow Analysis panel to toggle markers for Ms, Hc, Mr, Ku
- expose marker clearing via PlotManager

## Testing
- `ruff check src/vsm_gui/widgets/analysis_panel.py src/vsm_gui/widgets/plot_pane.py src/vsm_gui/plotting/manager.py` (fails: F401, E501, E702...)
- `PYTHONPATH=src pytest -q` (fails: libGL.so.1: cannot open shared object file)


------
https://chatgpt.com/codex/tasks/task_e_689caa8c566c832480adffceb5d042cd