### PR TITLE
feat: add paramag auto window detection

### DIFF
--- a/src/vsm_gui/widgets/analysis_panel.py
+++ b/src/vsm_gui/widgets/analysis_panel.py
@@ -313,6 +313,36 @@ class AnalysisDock(QDockWidget):
     def fit_and_preview(self) -> None:
         self._clear_fit_lines()
         hmin, hmax = self._parse_window()
+        if hmin is None and hmax is None:
+            labels = self._selected_labels()
+            if not labels:
+                return
+            try:
+                df0, x0, y0 = self.manager.get_dataset_tuple(labels[0])
+            except ValueError:
+                return
+            try:
+                det = paramag.detect_linear_tail(df0, x0, y0)
+                use_auto = prompts.confirm_detected_window(
+                    self, det["hmin"], det["hmax"]
+                )
+                if use_auto:
+                    hmin, hmax = det["hmin"], det["hmax"]
+                else:
+                    vals = prompts.prompt_field_window(
+                        self, det["hmin"], det["hmax"]
+                    )
+                    if vals is None:
+                        return
+                    hmin, hmax = vals
+            except Exception:
+                vals = prompts.prompt_field_window(self)
+                if vals is None:
+                    return
+                hmin, hmax = vals
+            self.hmin_edit.setText(f"{hmin:.6g}")
+            self.hmax_edit.setText(f"{hmax:.6g}")
+
         self._fit_results.clear()
 
         for label in self._selected_labels():

--- a/src/vsm_gui/widgets/prompts.py
+++ b/src/vsm_gui/widgets/prompts.py
@@ -9,6 +9,7 @@ from PyQt6.QtWidgets import (
     QDoubleSpinBox,
     QFormLayout,
     QInputDialog,
+    QMessageBox,
     QWidget,
 )
 
@@ -68,6 +69,24 @@ def prompt_field_window(
     if dialog.exec() == QDialog.DialogCode.Accepted:
         return dialog.values()
     return None
+
+
+def confirm_detected_window(parent: QWidget, hmin: float, hmax: float) -> bool:
+    """Confirm use of an auto-detected field window.
+
+    Returns ``True`` if the user chooses the detected window, ``False`` if the
+    user wants to pick values manually.
+    """
+    box = QMessageBox(parent)
+    box.setWindowTitle("Auto-detected window")
+    box.setText(
+        "A high-field linear region was detected automatically.\n"
+        f"Hmin = {hmin:.3g}\nHmax = {hmax:.3g}"
+    )
+    use_btn = box.addButton("Use detected", QMessageBox.ButtonRole.AcceptRole)
+    manual_btn = box.addButton("Choose manually...", QMessageBox.ButtonRole.ActionRole)
+    box.exec()
+    return box.clickedButton() is use_btn
 
 
 # ---- Sample parameters prompt (unit conversion helpers) ----


### PR DESCRIPTION
## Summary
- add quantile-based helper to detect high-field linear window for paramagnetic fits
- prompt users to accept detected window or enter values manually
- auto-fill fields and fit with overlay to preview correction

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cad71128c8324add9025ac8d9a1a7