### PR TITLE
Improve paramagnetic correction workflow

### DIFF
--- a/src/vsm_gui/utils/errors.py
+++ b/src/vsm_gui/utils/errors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QMessageBox, QWidget
 
 DEFAULT_ERROR_TITLE = "Error"
@@ -13,3 +14,14 @@ def show_error(parent: QWidget, message: str, title: str = DEFAULT_ERROR_TITLE) 
 def show_info(parent: QWidget, message: str, title: str) -> None:
     """Display an informational message box."""
     QMessageBox.information(parent, title, message)
+
+
+def show_warning(parent: QWidget, message: str, title: str = "Warning") -> None:
+    """Display a warning message without blocking interaction."""
+    box = QMessageBox(parent)
+    box.setIcon(QMessageBox.Icon.Warning)
+    box.setWindowTitle(title)
+    box.setText(message)
+    box.setStandardButtons(QMessageBox.StandardButton.Ok)
+    box.setWindowModality(Qt.WindowModality.NonModal)
+    box.show()


### PR DESCRIPTION
## Summary
- add `confirm_fit_window` dialog with stats and manual override
- overlay previewed fits and corrections with dashed style and show non-blocking warnings
- document field window edits with tooltip

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_689caf0fde548324878f8338b3422b69