### PR TITLE
Preserve intercept during paramagnetic subtraction

### DIFF
--- a/src/vsm_gui/analysis/paramag.py
+++ b/src/vsm_gui/analysis/paramag.py
@@ -126,11 +126,30 @@ def detect_linear_tail(
 def apply_subtraction(
     df: pd.DataFrame, x_name: str, y_name: str, chi: float, b: float
 ) -> pd.DataFrame:
-    """Subtract chi*H + b from the dataset.
+    """Subtract ``chi*H`` from the dataset, preserving the intercept ``b``.
 
-    Returns a copy of ``df`` with a new column ``y_name + '_corr'``.
+    The linear fit ``M ≈ chi*H + b`` is still reported to the caller, but only
+    the slope term is removed from the data so that any ferromagnetic content
+    (e.g. remanent magnetization) remains unchanged.  A copy of ``df`` is
+    returned with a new column ``y_name + '_corr'`` holding the corrected
+    values.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Input data containing ``x_name`` and ``y_name`` columns.
+    x_name, y_name : str
+        Column names for the field ``H`` and magnetization ``M``.
+    chi : float
+        Fitted paramagnetic susceptibility.
+    b : float
+        Intercept from the fit.  Kept for diagnostic purposes and not used in
+        the subtraction.
     """
+
     df_corr = df.copy()
     y_corr = y_name + "_corr"
-    df_corr[y_corr] = df_corr[y_name] - (chi * df_corr[x_name] + b)
+    # Subtract only the slope term; leave the intercept untouched so that
+    # vertical positioning (e.g. Mr, Ms) is preserved.
+    df_corr[y_corr] = df_corr[y_name] - chi * df_corr[x_name]
     return df_corr

--- a/src/vsm_gui/widgets/analysis_panel.py
+++ b/src/vsm_gui/widgets/analysis_panel.py
@@ -97,6 +97,12 @@ class AnalysisDock(QDockWidget):
         paramag_group = QGroupBox("Paramagnetic subtraction", corrections)
         form = QFormLayout(paramag_group)
 
+        info = QLabel(
+            "Subtract χ·H (slope only). Intercept b is shown for diagnostics."
+        )
+        info.setWordWrap(True)
+        form.addRow(info)
+
         self.hmin_edit = QLineEdit()
         self.hmax_edit = QLineEdit()
         tip = (

--- a/tests/test_paramag_subtraction.py
+++ b/tests/test_paramag_subtraction.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pandas as pd
+
+from vsm_gui.analysis import paramag
+
+
+def test_paramag_subtraction_preserves_intercept_and_remanence():
+    rng = np.random.default_rng(0)
+    h = np.linspace(-10, 10, 1001)
+    ms = 1.23
+    chi = 0.05
+    noise = rng.normal(scale=1e-3, size=h.size)
+    m = ms + chi * h + noise
+
+    df = pd.DataFrame({"H": h, "M": m})
+
+    # Fit the linear tail and subtract only the paramagnetic slope
+    res = paramag.fit_linear_tail(df, "H", "M")
+    df_corr = paramag.apply_subtraction(df, "H", "M", res["chi"], res["b"])
+
+    # High-field region mean should be close to Ms (intercept retained)
+    mask = np.abs(df_corr["H"]) > 8
+    mean_high = df_corr.loc[mask, "M_corr"].mean()
+    assert np.isclose(mean_high, ms, atol=5e-3)
+
+    # Remanence at H=0 remains unchanged because intercept is not subtracted
+    idx0 = np.argmin(np.abs(df["H"]))
+    assert np.isclose(
+        df_corr.loc[idx0, "M_corr"], df.loc[idx0, "M"], atol=1e-8
+    )
+


### PR DESCRIPTION
## Summary
- Correct paramagnetic subtraction to remove only χ·H slope while preserving intercept b
- Clarify UI that subtraction uses slope only and b is diagnostic
- Add regression test verifying remanence and high-field mean remain after correction

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cb4797e8883249ae2516c15f62e4f