### PR TITLE
Improve paramagnetic window auto-detection and prompting

### DIFF
--- a/src/vsm_gui/widgets/analysis_panel.py
+++ b/src/vsm_gui/widgets/analysis_panel.py
@@ -334,24 +334,31 @@ class AnalysisDock(QDockWidget):
             except ValueError:
                 return
             try:
-                det = paramag.detect_linear_tail(df0, x0, y0)
-                choice, vals = prompts.confirm_fit_window(
+                det = paramag.autodetect_window(df0, x0, y0)
+            except Exception as exc:  # noqa: BLE001
+                errors.show_warning(
                     self,
-                    det["hmin"],
-                    det["hmax"],
-                    {"npoints": det["npoints"], "r2": det["r2"]},
+                    f"Auto-detect failed: {exc}. Please enter Hmin/Hmax manually.",
+                    title="Fit Warning",
                 )
-                if choice == "auto":
-                    hmin, hmax = det["hmin"], det["hmax"]
-                elif choice == "manual" and vals is not None:
-                    hmin, hmax = vals
-                else:
-                    return
-            except Exception:
-                vals = prompts.prompt_field_window(self)
+                return
+
+            choice = prompts.confirm_fit_window(
+                self,
+                det["hmin"],
+                det["hmax"],
+                det,
+            )
+            if choice == "auto":
+                hmin, hmax = det["hmin"], det["hmax"]
+            elif choice == "manual":
+                vals = prompts.prompt_field_window(self, det["hmin"], det["hmax"])
                 if vals is None:
                     return
                 hmin, hmax = vals
+            else:
+                return
+
             self.hmin_edit.setText(f"{hmin:.6g}")
             self.hmax_edit.setText(f"{hmax:.6g}")
 

--- a/src/vsm_gui/widgets/prompts.py
+++ b/src/vsm_gui/widgets/prompts.py
@@ -95,7 +95,7 @@ def confirm_fit_window(
     hmin: float,
     hmax: float,
     stats: Mapping[str, float],
-) -> tuple[Literal["auto", "manual", "cancel"], tuple[float, float] | None]:
+) -> Literal["auto", "manual", "cancel"]:
     """Confirm use of an auto-detected field window with fit statistics."""
 
     box = QMessageBox(parent)
@@ -103,21 +103,21 @@ def confirm_fit_window(
     box.setText(
         "A high-field linear region was detected automatically.\n"
         f"Hmin = {hmin:.3g}\nHmax = {hmax:.3g}\n"
-        f"Points = {int(stats.get('npoints', 0))}\nR² = {stats.get('r2', 0):.3f}"
+        f"Points = {int(stats.get('npoints', 0))}\n"
+        f"χ = {stats.get('chi', 0):.3g}\nR² = {stats.get('r2', 0):.3f}"
     )
     use_btn = box.addButton("Use detected", QMessageBox.ButtonRole.AcceptRole)
-    manual_btn = box.addButton("Choose manually...", QMessageBox.ButtonRole.ActionRole)
+    manual_btn = box.addButton(
+        "Choose manually...", QMessageBox.ButtonRole.ActionRole
+    )
     box.addButton(QMessageBox.StandardButton.Cancel)
     box.exec()
     clicked = box.clickedButton()
     if clicked is use_btn:
-        return "auto", (hmin, hmax)
+        return "auto"
     if clicked is manual_btn:
-        vals = prompt_field_window(parent, hmin, hmax)
-        if vals is None:
-            return "cancel", None
-        return "manual", vals
-    return "cancel", None
+        return "manual"
+    return "cancel"
 
 
 # ---- Sample parameters prompt (unit conversion helpers) ----

--- a/tests/test_autodetect_window.py
+++ b/tests/test_autodetect_window.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from vsm_gui.analysis import paramag
+
+
+def test_autodetect_window_success():
+    rng = np.random.default_rng(0)
+    h = np.linspace(-10, 10, 101)
+    chi = 0.05
+    m = chi * h + rng.normal(scale=1e-3, size=h.size)
+    df = pd.DataFrame({"H": h, "M": m})
+
+    res = paramag.autodetect_window(df, "H", "M")
+
+    assert set(res.keys()) == {"hmin", "hmax", "chi", "b", "npoints", "r2"}
+    assert res["r2"] > 0.7
+    threshold = np.quantile(np.abs(h), 0.8)
+    mask = np.abs(h) >= threshold
+    assert np.isclose(res["hmin"], h[mask].min())
+    assert np.isclose(res["hmax"], h[mask].max())
+
+
+def test_autodetect_window_poor_fit_raises():
+    rng = np.random.default_rng(1)
+    h = np.linspace(-10, 10, 100)
+    m = rng.normal(size=h.size)
+    df = pd.DataFrame({"H": h, "M": m})
+
+    with pytest.raises(ValueError):
+        paramag.autodetect_window(df, "H", "M")


### PR DESCRIPTION
## Summary
- add autodetect_window to locate high-field linear region and compute stats
- show chi/r²/npoints in confirmation dialog with manual override option
- wire auto-detect/confirm flow in Analysis panel; warn when detection fails
- cover autodetect_window behaviour with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cb6d3ab2083248720611b53636c29