### PR TITLE
Refine magnetic metric calculations and add robustness tests

### DIFF
--- a/src/vsm_gui/analysis/metrics.py
+++ b/src/vsm_gui/analysis/metrics.py
@@ -17,21 +17,13 @@ def saturation_magnetization(
     window: tuple[float, float] | None = None,
     convert: bool = False,
     params: dict | None = None,
+    q: float = 0.8,
 ) -> tuple[float, dict]:
-    """Estimate saturation magnetization using a high-field linear fit.
+    """Estimate saturation magnetisation via high-field linear regression.
 
-    Parameters
-    ----------
-    df, x_name, y_name:
-        Data and column names.
-    window:
-        Optional ``(Hmin, Hmax)`` selection for high-field region. If not
-        provided the top 10\% of the field range is used.
-    convert:
-        If ``True`` convert moment to magnetisation (A/m) using ``params``.
-    params:
-        Mapping containing optional ``mass``, ``density``, ``thickness`` and
-        ``area`` entries.
+    A linear model ``M ≈ Ms + χH`` is fitted on the high-field tails. If a
+    ``window`` is not provided the fit uses points where ``|H|`` falls in the
+    upper quantile ``q`` (default 0.8).
     """
     h = _prepare_series(df[x_name])
     m = _prepare_series(df[y_name])
@@ -39,24 +31,29 @@ def saturation_magnetization(
         raise ValueError("No numeric data")
 
     if window is None:
-        hmin = h.min() + 0.9 * (h.max() - h.min())
-        hmax = h.max()
+        thresh = np.quantile(np.abs(h), q)
+        mask = np.abs(h) >= thresh
+        if mask.sum() < 2:
+            raise ValueError("Insufficient points in high-field tails")
+        hmin, hmax = h[mask].min(), h[mask].max()
     else:
         hmin, hmax = window
+        mask = (h >= hmin) & (h <= hmax)
+        if mask.sum() < 2:
+            raise ValueError("Insufficient points in high-field window")
 
-    mask = (h >= hmin) & (h <= hmax)
-    if mask.sum() < 2:
-        raise ValueError("Insufficient points in high-field window")
     x = h[mask]
     y = m[mask]
 
-    coeffs = np.polyfit(x, y, 1)
-    chi, ms = coeffs[0], coeffs[1]
-    p = np.poly1d(coeffs)
-    yhat = p(x)
-    ss_res = np.sum((y - yhat) ** 2)
-    ss_tot = np.sum((y - np.mean(y)) ** 2)
-    r2 = 1 - ss_res / ss_tot if ss_tot != 0 else 1.0
+    x_fit = np.abs(x)
+    y_fit = np.sign(x) * y
+    A = np.column_stack([np.ones_like(x_fit), x_fit])
+    coeffs, residuals, rank, s = np.linalg.lstsq(A, y_fit, rcond=None)
+    ms, chi = coeffs[0], coeffs[1]
+    if residuals.size > 0 and x.size > 2:
+        stderr = float(np.sqrt(residuals[0] / (x.size - 2)))
+    else:
+        stderr = float("nan")
     unit = "raw"
 
     if convert and params:
@@ -71,47 +68,82 @@ def saturation_magnetization(
             volume = thickness * area
         if volume and volume > 0:
             ms = ms / volume
+            stderr = stderr / volume if not np.isnan(stderr) else stderr
             unit = "A/m"
 
-    return ms, {"chi": chi, "r2": r2, "window": (hmin, hmax), "unit": unit}
+    return ms, {"chi": chi, "stderr": stderr, "window": (hmin, hmax), "unit": unit}
 
 
 def coercivity(df: pd.DataFrame, x_name: str, y_name: str) -> tuple[float, dict]:
-    """Determine coercive field by locating M=0 crossings."""
+    """Determine coercive field by locating ``M=0`` crossings on each branch."""
     h = _prepare_series(df[x_name])
     m = _prepare_series(df[y_name])
-    if h.size < 2 or m.size < 2:
+    if h.size < 4 or m.size < 4:
         raise ValueError("Not enough data points")
-    idx = np.argsort(h)
-    h = h[idx]
-    m = m[idx]
-    zeros: list[float] = []
-    for i in range(len(h) - 1):
-        m1, m2 = m[i], m[i + 1]
-        if m1 == m2:
-            continue
-        if m1 == 0:
-            zeros.append(h[i])
-        elif (m1 < 0 and m2 > 0) or (m1 > 0 and m2 < 0):
-            h1, h2 = h[i], h[i + 1]
+
+    mid = h.size // 2
+    h1, m1 = h[:mid], m[:mid]
+    h2, m2 = h[mid:], m[mid:]
+
+    # Determine orientation of branches
+    if h1[-1] > h1[0]:
+        asc_h, asc_m = h1, m1
+        desc_h, desc_m = h2, m2
+    else:
+        desc_h, desc_m = h1, m1
+        asc_h, asc_m = h2, m2
+
+    def _branch_zero(hb: np.ndarray, mb: np.ndarray) -> float:
+        idxs = np.where(np.diff(np.sign(mb)) != 0)[0]
+        if idxs.size == 0:
+            raise ValueError("No zero crossing found on branch")
+        zeros = []
+        for i in idxs:
+            h1, h2 = hb[i], hb[i + 1]
+            m1, m2 = mb[i], mb[i + 1]
             hz = h1 + (h2 - h1) * (-m1) / (m2 - m1)
             zeros.append(hz)
-    if not zeros:
-        raise ValueError("No zero crossing found")
-    hc = float(np.mean(np.abs(zeros)))
-    return hc, {"zeros": zeros}
+        return min(zeros, key=lambda v: abs(v))
+
+    hz_asc = _branch_zero(asc_h, asc_m)
+    hz_desc = _branch_zero(desc_h, desc_m)
+    hc = float(0.5 * (abs(hz_asc) + abs(hz_desc)))
+    return hc, {"ascending": hz_asc, "descending": hz_desc, "unit": "raw"}
 
 
-def remanence(df: pd.DataFrame, x_name: str, y_name: str) -> tuple[float, dict]:
-    """Interpolate magnetisation at H=0."""
+def remanence(
+    df: pd.DataFrame,
+    x_name: str,
+    y_name: str,
+    fit_points: int = 4,
+    smooth: bool = False,
+) -> tuple[float, dict]:
+    """Interpolate magnetisation at ``H=0`` using local linear fit."""
     h = _prepare_series(df[x_name])
     m = _prepare_series(df[y_name])
     if h.size < 2 or m.size < 2:
         raise ValueError("Not enough data points")
-    idx = np.argsort(h)
-    h = h[idx]
-    m = m[idx]
     if not (h.min() <= 0 <= h.max()):
         raise ValueError("Field does not include 0")
-    mr = float(np.interp(0.0, h, m))
-    return mr, {}
+
+    if smooth:
+        try:
+            from scipy.signal import savgol_filter
+
+            win = min(len(m) // 2 * 2 + 1, 7)
+            if win >= 3:
+                m = savgol_filter(m, win, 1)
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError("Savitzky–Golay smoothing failed") from exc
+
+    order = np.argsort(np.abs(h))
+    n = min(max(fit_points, 2), order.size)
+    sel = order[:n]
+    x = h[sel]
+    y = m[sel]
+
+    A = np.column_stack([x, np.ones_like(x)])
+    coeffs, _, _, _ = np.linalg.lstsq(A, y, rcond=None)
+    slope, intercept = coeffs[0], coeffs[1]
+    mr = float(intercept)
+    return mr, {"slope": slope, "n": n, "unit": "raw"}

--- a/tests/test_metrics_precise.py
+++ b/tests/test_metrics_precise.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pandas as pd
+
+from vsm_gui.analysis import metrics
+
+
+def _make_loop(offset: float = 0.0, noise: float = 0.0, seed: int = 0):
+    Ms = 1.0
+    H0 = 500.0
+    chi = 1e-4
+    H_up = np.linspace(-10000, 10000, 1001)
+    H_down = np.linspace(10000, -10000, 1001)[1:]
+    H = np.concatenate([H_up, H_down])
+    M = Ms * np.tanh(H / H0) + chi * H + offset
+    if noise:
+        rng = np.random.default_rng(seed)
+        M = M + noise * rng.standard_normal(M.shape)
+    df = pd.DataFrame({"H": H, "M": M})
+    return df, Ms, H0, chi
+
+
+def _solve_hc(Ms: float, H0: float, chi: float, offset: float) -> float:
+    def f(H: float) -> float:
+        return Ms * np.tanh(H / H0) + chi * H + offset
+
+    a, b = -1000.0, 0.0
+    for _ in range(60):
+        c = 0.5 * (a + b)
+        if f(a) * f(c) <= 0:
+            b = c
+        else:
+            a = c
+    return abs(0.5 * (a + b))
+
+
+def test_metrics_precise_clean():
+    df, Ms_true, H0, _ = _make_loop()
+    ms, _ = metrics.saturation_magnetization(df, "H", "M")
+    assert np.isclose(ms, Ms_true, rtol=0.02)
+    hc, _ = metrics.coercivity(df, "H", "M")
+    assert abs(hc) < 0.02 * H0
+    mr, _ = metrics.remanence(df, "H", "M")
+    assert abs(mr) < 0.02 * Ms_true
+
+
+def test_metrics_precise_noisy_offset():
+    offset = 0.05
+    df, Ms_true, H0, chi = _make_loop(offset=offset, noise=0.01, seed=1)
+    ms, _ = metrics.saturation_magnetization(df, "H", "M")
+    assert np.isclose(ms, Ms_true, rtol=0.05)
+    hc_true = _solve_hc(Ms_true, H0, chi, offset)
+    hc, _ = metrics.coercivity(df, "H", "M")
+    assert np.isclose(hc, hc_true, rtol=0.2)
+    mr, _ = metrics.remanence(df, "H", "M")
+    assert np.isclose(mr, offset, rtol=0.05)


### PR DESCRIPTION
## Summary
- Improve Ms, Hc and Mr calculations with linear regression, branch separation and optional smoothing
- Add plot markers for Ms/Hc/Mr and ensure they clear reliably
- Introduce synthetic-loop tests validating precision and noise robustness

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cc04878c883248347291dc6a9bd3f