### PR TITLE
Ensure type-safe settings and robust Format dialog

### DIFF
--- a/src/vsm_gui/utils/settings.py
+++ b/src/vsm_gui/utils/settings.py
@@ -7,12 +7,43 @@ class AppSettings:
     """Thin wrapper around :class:`QSettings` for per-user persistence."""
 
     def __init__(self) -> None:
-        self._s = QSettings("YourLab", "VSM-GUI")
+        self._settings = QSettings("YourLab", "VSM-GUI")
 
     def get(self, key: str, default=None):  # noqa: ANN001 - Qt types
         """Return the stored value for *key* or *default* if missing."""
-        return self._s.value(key, default)
+        return self._settings.value(key, default)
+
+    # Typed getters -----------------------------------------------------
+    def get_str(self, key: str, default: str = "") -> str:
+        val = self._settings.value(key, default)
+        if val is None:
+            return default
+        return str(val)
+
+    def get_bool(self, key: str, default: bool = False) -> bool:
+        val = self._settings.value(key, default)
+        if isinstance(val, bool):
+            return val
+        if isinstance(val, (int, float)):
+            return bool(val)
+        if isinstance(val, str):
+            return val.strip().lower() in ("1", "true", "yes", "on")
+        return default
+
+    def get_int(self, key: str, default: int = 0) -> int:
+        val = self._settings.value(key, default)
+        try:
+            return int(float(val))
+        except Exception:
+            return default
+
+    def get_float(self, key: str, default: float = 0.0) -> float:
+        val = self._settings.value(key, default)
+        try:
+            return float(val)
+        except Exception:
+            return default
 
     def set(self, key: str, value) -> None:  # noqa: ANN001 - Qt types
         """Store *value* under *key*."""
-        self._s.setValue(key, value)
+        self._settings.setValue(key, value)


### PR DESCRIPTION
## Summary
- add typed getter helpers to `AppSettings` with safe coercion for strings, bools, ints and floats
- update Format dialog to load/save settings using typed accessors and to persist numeric types explicitly
- guard log scale limits, warning and adjusting invalid (<=0) values

## Testing
- `PYTHONPATH=src pytest tests/test_extension_points.py -q`
- `PYTHONPATH=src pytest tests/test_format_dialog.py::test_trace_style_and_axes_updates -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_689e1db5a8888324999938cae9bdf8e1